### PR TITLE
Eliminate trailing spaces in server address

### DIFF
--- a/src/main/java/acs/tabbychat/util/IPResolver.java
+++ b/src/main/java/acs/tabbychat/util/IPResolver.java
@@ -8,6 +8,7 @@ public class IPResolver {
     private int port;
 
     public IPResolver(String ipaddress) {
+        ipaddress = ipaddress.trim();
         EnumConnection type = getType(ipaddress);
         switch (type) {
         case DOMAIN:


### PR DESCRIPTION
The Minecraft client allows for servers to have addresses with trailing spaces (a likely occurrence when copy-pasting from websites occurs).
Changed so the address is `trim()`-ed before it's parsed.
